### PR TITLE
Enums in Query Filters

### DIFF
--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/query/expr/EnumPath.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/query/expr/EnumPath.java
@@ -15,8 +15,12 @@
  *******************************************************************************/
 package com.intuit.ipp.query.expr;
 
+import com.intuit.ipp.data.AccountTypeEnum;
 import com.intuit.ipp.query.Operation;
 import com.intuit.ipp.query.Path;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 /**
  * Class to generate the query string for enum value
@@ -41,7 +45,7 @@ public class EnumPath extends Path<Enum<?>> {
 	 * @return Expression
 	 */
 	public Expression<Enum<?>> eq(Enum<?> value) {
-		String valueString = "'" + value + "'";
+		String valueString = "'" + EnumPath.getValue(value) + "'";
 		return new Expression<Enum<?>>(this, Operation.eq, valueString);
 	}
 
@@ -52,7 +56,7 @@ public class EnumPath extends Path<Enum<?>> {
 	 * @return Expression
 	 */
 	public Expression<Enum<?>> neq(Enum<?> value) {
-		String valueString = "'" + value + "'";
+		String valueString = "'" + EnumPath.getValue(value) + "'";
 		return new Expression<Enum<?>>(this, Operation.neq, valueString);
 	}
 
@@ -63,7 +67,7 @@ public class EnumPath extends Path<Enum<?>> {
 	 * @return Expression
 	 */
 	public Expression<Enum<?>> lt(Enum<?> value) {
-		String valueString = "'" + value + "'";
+		String valueString = "'" + EnumPath.getValue(value) + "'";
 		return new Expression<Enum<?>>(this, Operation.lt, valueString);
 	}
 
@@ -74,7 +78,7 @@ public class EnumPath extends Path<Enum<?>> {
 	 * @return Expression
 	 */
 	public Expression<Enum<?>> lte(Enum<?> value) {
-		String valueString = "'" + value + "'";
+		String valueString = "'" + EnumPath.getValue(value) + "'";
 		return new Expression<Enum<?>>(this, Operation.lte, valueString);
 	}
 
@@ -85,7 +89,7 @@ public class EnumPath extends Path<Enum<?>> {
 	 * @return Expression
 	 */
 	public Expression<Enum<?>> gt(Enum<?> value) {
-		String valueString = "'" + value + "'";
+		String valueString = "'" + EnumPath.getValue(value) + "'";
 		return new Expression<Enum<?>>(this, Operation.gt, valueString);
 	}
 
@@ -96,7 +100,7 @@ public class EnumPath extends Path<Enum<?>> {
 	 * @return Expression
 	 */
 	public Expression<Enum<?>> gte(Enum<?> value) {
-		String valueString = "'" + value + "'";
+		String valueString = "'" + EnumPath.getValue(value) + "'";
 		return new Expression<Enum<?>>(this, Operation.gte, valueString);
 	}
 
@@ -111,13 +115,30 @@ public class EnumPath extends Path<Enum<?>> {
 		Boolean firstString = true;
 		for (Enum<?> v : value) {
 			if (firstString) {
-				listString = listString.concat("('").concat(v.toString()).concat("'");
+				listString = listString.concat("('").concat(EnumPath.getValue(v)).concat("'");
 				firstString = false;
 			} else {
-				listString = listString.concat(", '").concat(v.toString()).concat("'");
+				listString = listString.concat(", '").concat(EnumPath.getValue(v)).concat("'");
 			}
 		}
 		listString = listString.concat(")");
 		return new Expression<Enum<?>>(this, Operation.in, listString);
 	}
+
+	/**
+	 * Intuit data enumerations have a value property which should be used in queries instead of enum names.
+	 * @param value The enumeration for which to get the query value.
+	 * @return The query value based on the given enumeration.
+	 */
+	private static String getValue(Enum<?> value){
+		try{
+			Method m = value.getClass().getDeclaredMethod("value");
+			return (String) m.invoke(value);
+		} catch (NoSuchMethodException ex){
+		} catch (IllegalAccessException ex){
+		} catch (InvocationTargetException ex){
+		}
+		return value.toString();
+	}
+
 }

--- a/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/query/QueryTest.java
+++ b/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/query/QueryTest.java
@@ -59,7 +59,7 @@ public class QueryTest {
 				$(data.getFloatData()).eq((float) 10), $(data.getDoubleData()).eq((double) 10), $(data.getCalendarData()).eq(calendar),
 				$(data.isBooleanData()).eq(true), $(data.getDateData()).eq(calendar.getTime()), $(data.getEnumData()).eq(EntityStatusEnum.PENDING))
 				.generate();
-		String expectedQuery = "SELECT StringData, IntData, ByteData, ShortData, LongData, FloatData, DoubleData, CalendarData, BooleanData, DateData, EnumData FROM Data WHERE StringData = 'StringValue' AND IntData = '10' AND ByteData = '10' AND ShortData = '10' AND LongData = '10' AND FloatData = '10.0' AND DoubleData = '10.0' AND CalendarData = '" + dateString + "' AND BooleanData = true AND DateData = '" + dateString + "' AND EnumData = 'PENDING'";
+		String expectedQuery = "SELECT StringData, IntData, ByteData, ShortData, LongData, FloatData, DoubleData, CalendarData, BooleanData, DateData, EnumData FROM Data WHERE StringData = 'StringValue' AND IntData = '10' AND ByteData = '10' AND ShortData = '10' AND LongData = '10' AND FloatData = '10.0' AND DoubleData = '10.0' AND CalendarData = '" + dateString + "' AND BooleanData = true AND DateData = '" + dateString + "' AND EnumData = 'Pending'";
 		Assert.assertEquals(expectedQuery, query);
 	}
 
@@ -71,7 +71,7 @@ public class QueryTest {
 				$(data.getFloatData()).eq((float) 10), $(data.getDoubleData()).eq((double) 10), $(data.getCalendarData()).eq(calendar),
 				$(data.isBooleanData()).eq(true), $(data.getDateData()).eq(calendar.getTime()), $(data.getEnumData()).eq(EntityStatusEnum.PENDING))
 				.generate();
-		String expectedQuery = "SELECT * FROM Data WHERE StringData = 'StringValue' AND IntData = '10' AND ByteData = '10' AND ShortData = '10' AND LongData = '10' AND FloatData = '10.0' AND DoubleData = '10.0' AND CalendarData = '" + dateString + "' AND BooleanData = true AND DateData = '" + dateString + "' AND EnumData = 'PENDING'";
+		String expectedQuery = "SELECT * FROM Data WHERE StringData = 'StringValue' AND IntData = '10' AND ByteData = '10' AND ShortData = '10' AND LongData = '10' AND FloatData = '10.0' AND DoubleData = '10.0' AND CalendarData = '" + dateString + "' AND BooleanData = true AND DateData = '" + dateString + "' AND EnumData = 'Pending'";
 
 		Assert.assertEquals(expectedQuery, query);
 	}
@@ -84,7 +84,7 @@ public class QueryTest {
 						$(data.getShortData()).neq((short) 10), $(data.getLongData()).neq((long) 10), $(data.getFloatData()).neq((float) 10),
 						$(data.getDoubleData()).neq((double) 10), $(data.getCalendarData()).neq(calendar), $(data.isBooleanData()).neq(true),
 						$(data.getDateData()).neq(calendar.getTime()), $(data.getEnumData()).neq(EntityStatusEnum.PENDING)).generate();
-		String expectedQuery = "SELECT * FROM Data WHERE StringData != 'StringValue' AND IntData != '10' AND ByteData != '10' AND ShortData != '10' AND LongData != '10' AND FloatData != '10.0' AND DoubleData != '10.0' AND CalendarData != '" + dateString + "' AND BooleanData != true AND DateData != '" + dateString + "' AND EnumData != 'PENDING'";
+		String expectedQuery = "SELECT * FROM Data WHERE StringData != 'StringValue' AND IntData != '10' AND ByteData != '10' AND ShortData != '10' AND LongData != '10' AND FloatData != '10.0' AND DoubleData != '10.0' AND CalendarData != '" + dateString + "' AND BooleanData != true AND DateData != '" + dateString + "' AND EnumData != 'Pending'";
 		LOG.debug(query);
 		Assert.assertEquals(expectedQuery, query);
 	}
@@ -96,7 +96,7 @@ public class QueryTest {
 				$(data.getByteData()).lt((byte) 10), $(data.getShortData()).lt((short) 10), $(data.getLongData()).lt((long) 10),
 				$(data.getFloatData()).lt((float) 10), $(data.getDoubleData()).lt((double) 10), $(data.getCalendarData()).lt(calendar),
 				$(data.getDateData()).lt(calendar.getTime()), $(data.getEnumData()).lt(EntityStatusEnum.PENDING)).generate();
-		String expectedQuery = "SELECT * FROM Data WHERE StringData < 'StringValue' AND IntData < '10' AND ByteData < '10' AND ShortData < '10' AND LongData < '10' AND FloatData < '10.0' AND DoubleData < '10.0' AND CalendarData < '" + dateString + "' AND DateData < '" + dateString + "' AND EnumData < 'PENDING'";
+		String expectedQuery = "SELECT * FROM Data WHERE StringData < 'StringValue' AND IntData < '10' AND ByteData < '10' AND ShortData < '10' AND LongData < '10' AND FloatData < '10.0' AND DoubleData < '10.0' AND CalendarData < '" + dateString + "' AND DateData < '" + dateString + "' AND EnumData < 'Pending'";
 		LOG.debug(query);
 		Assert.assertEquals(expectedQuery, query);
 	}
@@ -108,7 +108,7 @@ public class QueryTest {
 				$(data.getByteData()).lte((byte) 10), $(data.getShortData()).lte((short) 10), $(data.getLongData()).lte((long) 10),
 				$(data.getFloatData()).lte((float) 10), $(data.getDoubleData()).lte((double) 10), $(data.getCalendarData()).lte(calendar),
 				$(data.getDateData()).lte(calendar.getTime()), $(data.getEnumData()).lte(EntityStatusEnum.PENDING)).generate();
-		String expectedQuery = "SELECT * FROM Data WHERE StringData <= 'StringValue' AND IntData <= '10' AND ByteData <= '10' AND ShortData <= '10' AND LongData <= '10' AND FloatData <= '10.0' AND DoubleData <= '10.0' AND CalendarData <= '" + dateString + "' AND DateData <= '" + dateString + "' AND EnumData <= 'PENDING'";
+		String expectedQuery = "SELECT * FROM Data WHERE StringData <= 'StringValue' AND IntData <= '10' AND ByteData <= '10' AND ShortData <= '10' AND LongData <= '10' AND FloatData <= '10.0' AND DoubleData <= '10.0' AND CalendarData <= '" + dateString + "' AND DateData <= '" + dateString + "' AND EnumData <= 'Pending'";
 		LOG.debug(query);
 		Assert.assertEquals(expectedQuery, query);
 	}
@@ -120,7 +120,7 @@ public class QueryTest {
 				$(data.getByteData()).gt((byte) 10), $(data.getShortData()).gt((short) 10), $(data.getLongData()).gt((long) 10),
 				$(data.getFloatData()).gt((float) 10), $(data.getDoubleData()).gt((double) 10), $(data.getCalendarData()).gt(calendar),
 				$(data.getDateData()).gt(calendar.getTime()), $(data.getEnumData()).gt(EntityStatusEnum.PENDING)).generate();
-		String expectedQuery = "SELECT * FROM Data WHERE StringData > 'StringValue' AND IntData > '10' AND ByteData > '10' AND ShortData > '10' AND LongData > '10' AND FloatData > '10.0' AND DoubleData > '10.0' AND CalendarData > '" + dateString + "' AND DateData > '" + dateString + "' AND EnumData > 'PENDING'";
+		String expectedQuery = "SELECT * FROM Data WHERE StringData > 'StringValue' AND IntData > '10' AND ByteData > '10' AND ShortData > '10' AND LongData > '10' AND FloatData > '10.0' AND DoubleData > '10.0' AND CalendarData > '" + dateString + "' AND DateData > '" + dateString + "' AND EnumData > 'Pending'";
 		LOG.debug(query);
 		Assert.assertEquals(expectedQuery, query);
 	}
@@ -132,7 +132,7 @@ public class QueryTest {
 				$(data.getByteData()).gte((byte) 10), $(data.getShortData()).gte((short) 10), $(data.getLongData()).gte((long) 10),
 				$(data.getFloatData()).gte((float) 10), $(data.getDoubleData()).gte((double) 10), $(data.getCalendarData()).gte(calendar),
 				$(data.getDateData()).gte(calendar.getTime()), $(data.getEnumData()).gte(EntityStatusEnum.PENDING)).generate();
-		String expectedQuery = "SELECT * FROM Data WHERE StringData >= 'StringValue' AND IntData >= '10' AND ByteData >= '10' AND ShortData >= '10' AND LongData >= '10' AND FloatData >= '10.0' AND DoubleData >= '10.0' AND CalendarData >= '" + dateString + "' AND DateData >= '" + dateString + "' AND EnumData >= 'PENDING'";
+		String expectedQuery = "SELECT * FROM Data WHERE StringData >= 'StringValue' AND IntData >= '10' AND ByteData >= '10' AND ShortData >= '10' AND LongData >= '10' AND FloatData >= '10.0' AND DoubleData >= '10.0' AND CalendarData >= '" + dateString + "' AND DateData >= '" + dateString + "' AND EnumData >= 'Pending'";
 		LOG.debug(query);
 		Assert.assertEquals(expectedQuery, query);
 	}
@@ -147,7 +147,7 @@ public class QueryTest {
 				$(data.isBooleanData()).in(new Boolean[] { true, false }), $(data.getCalendarData()).in(new Calendar[] { calendar, calendar }),
 				$(data.getDateData()).in(new Date[] { calendar.getTime(), calendar.getTime() }),
 				$(data.getEnumData()).in(new EntityStatusEnum[] { EntityStatusEnum.PENDING, EntityStatusEnum.DELETED })).generate();
-		String expectedQuery = "SELECT * FROM Data WHERE StringData IN ('StringValue1', 'StringValue2') AND IntData IN ('10', '20') AND ByteData IN ('10', '20') AND ShortData IN ('10', '20') AND LongData IN ('10', '20') AND FloatData IN ('10.0', '20.0') AND DoubleData IN ('10.0', '20.0') AND BooleanData IN (true, false) AND CalendarData IN ('" + dateString + "', '" + dateString + "') AND DateData IN ('" + dateString + "', '" + dateString + "') AND EnumData IN ('PENDING', 'DELETED')";
+		String expectedQuery = "SELECT * FROM Data WHERE StringData IN ('StringValue1', 'StringValue2') AND IntData IN ('10', '20') AND ByteData IN ('10', '20') AND ShortData IN ('10', '20') AND LongData IN ('10', '20') AND FloatData IN ('10.0', '20.0') AND DoubleData IN ('10.0', '20.0') AND BooleanData IN (true, false) AND CalendarData IN ('" + dateString + "', '" + dateString + "') AND DateData IN ('" + dateString + "', '" + dateString + "') AND EnumData IN ('Pending', 'Deleted')";
 		LOG.debug(query);
 		Assert.assertEquals(expectedQuery, query);
 	}


### PR DESCRIPTION
Currently, when generating queries with Enum properties the code uses Enum.toString() as a value which is used in the Service query as a result Service Endpoint returns error `Services V3 Query Value for XXX.XXX must be a valid enumeration value`. When using Enums from `ipp-v3-java-data` the `Enum.value()` method should be used to get the correct query value.

Example 
```java
Account accountProxy = GenerateQuery.createQueryEntity(Account.class);
String query = select($(accountProxy)).where($(accountProxy.getName()).eq("Some Name")).where($(accountProxy.getAccountType()).eq(AccountTypeEnum.BANK)).generate();
QueryResult queryResult = service.executeQuery(query);
```
Ends up with `ERROR CODE:10000, ERROR MESSAGE:An application error has occurred while processing your request, ERROR DETAIL:System Failure Error: Services V3 Query Value for Account.AccountType must be a valid enumeration value`
