### PR TITLE
add tests for Address and BankAccount models

### DIFF
--- a/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/interceptors/CompressionInterceptorTest.java
+++ b/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/interceptors/CompressionInterceptorTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.intuit.ipp.interceptors;
+
+import com.intuit.ipp.compression.CompressorFactory;
+import com.intuit.ipp.compression.DeflateCompressor;
+import com.intuit.ipp.compression.GZIPCompressor;
+import com.intuit.ipp.exception.FMSException;
+import com.intuit.ipp.util.Config;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class CompressionInterceptorTest {
+
+    private CompressionInterceptor instance;
+    private IntuitMessage message;
+    private String compressorConfigPropertyPriorTest;
+
+    @BeforeTest
+    public void GetCurrentCompressionProperty() {
+        compressorConfigPropertyPriorTest = Config.getProperty(Config.COMPRESSION_REQUEST_FORMAT);
+    }
+
+    @AfterTest
+    public void ResetCompressionProperty(){
+        Config.setProperty(Config.COMPRESSION_REQUEST_FORMAT,compressorConfigPropertyPriorTest);
+    }
+
+    @BeforeMethod
+    public void InitTest() {
+        // Fresh message and compressor to ensure tests runs are completely independent
+        message = new IntuitMessage();
+        instance = new CompressionInterceptor();
+    }
+
+    @Test
+    public void CompressionNoFormatTest() throws FMSException {
+        String testMessage = "Test No Format Serialized";
+
+        // No Compression format test case
+        Config.setProperty(Config.COMPRESSION_REQUEST_FORMAT, "");
+
+        message.getRequestElements().setSerializedData(testMessage);
+        instance.execute(message);
+
+        Assert.assertEquals(message.getRequestElements().getCompressedData(), testMessage.getBytes());
+    }
+
+    @Test
+    public void CompressionNoFormatAndUploadFileTest() throws FMSException {
+        String testMessage = "Test No Format and Upload Serialized";
+        String testUploadFile = "Test Upload File";
+        byte[] allBytes = (testMessage + testUploadFile).getBytes();
+
+        // No Compression format test case
+        Config.setProperty(Config.COMPRESSION_REQUEST_FORMAT, "");
+
+        message.getRequestElements().setSerializedData(testMessage);
+        message.getRequestElements().setUploadFile(testUploadFile.getBytes());
+        instance.execute(message);
+
+        Assert.assertEquals(message.getRequestElements().getCompressedData(), allBytes);
+    }
+
+    @Test
+    public void CompressionGZipFormatCompressionTest() throws FMSException {
+        String testMessage = "Test Gzip Serialized";
+        GZIPCompressor compressor = new GZIPCompressor();
+        byte[] compressed = compressor.compress(testMessage, null);
+
+        Config.setProperty(Config.COMPRESSION_REQUEST_FORMAT, CompressorFactory.GZIP_COMPRESS_FORMAT);
+
+        message.getRequestElements().setSerializedData(testMessage);
+        instance.execute(message);
+
+        Assert.assertEquals(message.getRequestElements().getCompressedData(), compressed);
+    }
+
+    @Test
+    public void CompressionDeflateFormatCompressionTest() throws FMSException {
+        String testMessage = "Test Deflate Serialized";
+        DeflateCompressor compressor = new DeflateCompressor();
+        byte[] compressed = compressor.compress(testMessage, null);
+
+        Config.setProperty(Config.COMPRESSION_REQUEST_FORMAT, CompressorFactory.DEFLATE_COMPRESS_FORMAT);
+
+        message.getRequestElements().setSerializedData(testMessage);
+        instance.execute(message);
+
+        Assert.assertEquals(message.getRequestElements().getCompressedData(), compressed);
+    }
+}

--- a/payments-api/src/test/java/com/intuit/payment/data/AddressTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/data/AddressTest.java
@@ -1,11 +1,12 @@
 package com.intuit.payment.data;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 /**
- * @author k-arjun
+ * @author k-arjun, enzozafra
  */
 public class AddressTest {
     private String streetAddress;
@@ -13,6 +14,7 @@ public class AddressTest {
     private String region;
     private String country;
     private String postalCode;
+    private Address address;
 
     @BeforeTest
     public void init() {
@@ -23,9 +25,9 @@ public class AddressTest {
         postalCode = "12345";
     }
 
-    @Test
-    public void testAllGetters() {
-        Address address = new Address.Builder()
+    @BeforeMethod
+    public void setUp() {
+        address = new Address.Builder()
                 .streetAddress(streetAddress)
                 .city(city)
                 .region(region)
@@ -33,10 +35,43 @@ public class AddressTest {
                 .postalCode(postalCode)
                 .build();
 
+    }
+
+    @Test
+    public void testAllGetters() {
         Assert.assertEquals(address.getStreetAddress(), streetAddress);
         Assert.assertEquals(address.getCity(), city);
         Assert.assertEquals(address.getRegion(), region);
         Assert.assertEquals(address.getCountry(), country);
         Assert.assertEquals(address.getPostalCode(), postalCode);
+    }
+
+    @Test
+    public void testAllSetters() {
+        String newStreetAddress = "321 New Street Address";
+        String newCity = "New City";
+        String newRegion = "New Region";
+        String newCountry = "New Country";
+        String newPostalCode = "54321";
+
+        address.setStreetAddress(newStreetAddress);
+        address.setCity(newCity);
+        address.setRegion(newRegion);
+        address.setCountry(newCountry);
+        address.setPostalCode(newPostalCode);
+
+        Assert.assertEquals(address.getStreetAddress(), newStreetAddress);
+        Assert.assertEquals(address.getCity(), newCity);
+        Assert.assertEquals(address.getRegion(), newRegion);
+        Assert.assertEquals(address.getCountry(), newCountry);
+        Assert.assertEquals(address.getPostalCode(), newPostalCode);
+    }
+
+    @Test
+    public void testToString() {
+        // Since we cant mock ReflectionToStringBuilder without powermock, just check if it includes below
+        String expectedResult = "[streetAddress=123 Test Street,city=city,region=region,country=country,postalCode=12345,intuit_tid=<null>,requestId=<null>]";
+        String actualResult = address.toString();
+        Assert.assertTrue(actualResult.contains(expectedResult));
     }
 }

--- a/payments-api/src/test/java/com/intuit/payment/data/AddressTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/data/AddressTest.java
@@ -1,5 +1,6 @@
 package com.intuit.payment.data;
 
+import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
@@ -70,7 +71,7 @@ public class AddressTest {
     @Test
     public void testToString() {
         // Since we cant mock ReflectionToStringBuilder without powermock, just check if it includes below
-        String expectedResult = "[streetAddress=123 Test Street,city=city,region=region,country=country,postalCode=12345,intuit_tid=<null>,requestId=<null>]";
+        String expectedResult = ReflectionToStringBuilder.toString(address);
         String actualResult = address.toString();
         Assert.assertTrue(actualResult.contains(expectedResult));
     }

--- a/payments-api/src/test/java/com/intuit/payment/data/BankAccountTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/data/BankAccountTest.java
@@ -1,5 +1,6 @@
 package com.intuit.payment.data;
 
+import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
@@ -143,8 +144,8 @@ public class BankAccountTest {
 
     @Test
     public void testToString() {
-        // Since we cant mock ReflectionToStringBuilder without powermock, just check if it includes below
-        String expectedResult = "[id=id,name=name,created=Wed Jan 14 19:57:07 MST 1970,updated=Wed Jan 14 20:07:12 MST 1970,inputType=KEYED,routingNumber=12311,accountNumber=123123123,accountType=PERSONAL_CHECKING,phone=5871231234,defaultValue=true,country=country,bankCode=1221,entityId=entityId,entityType=entityType,entityVersion=entityVersion,intuit_tid=<null>,requestId=<null>]";
+        // Since we cant mock ReflectionToStringBuilder without powermock
+        String expectedResult = ReflectionToStringBuilder.toString(bankAccount);
         String actualResult = bankAccount.toString();
         Assert.assertTrue(actualResult.contains(expectedResult));
     }

--- a/payments-api/src/test/java/com/intuit/payment/data/BankAccountTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/data/BankAccountTest.java
@@ -1,0 +1,151 @@
+package com.intuit.payment.data;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+import com.intuit.payment.data.BankAccount.BankAccountInputTypeEnum;
+import com.intuit.payment.data.BankAccount.AccountType;
+
+/**
+ * @author enzozafra
+ */
+public class BankAccountTest {
+    private String id;
+    private String name;
+    private Date created;
+    private Date updated;
+    private BankAccountInputTypeEnum inputType;
+    private String routingNumber;
+    private String accountNumber;
+    private AccountType accountType;
+    private String phone;
+    private Boolean defaultValue;
+    private String country;
+    private String bankCode;
+    private String entityId;
+    private String entityType;
+    private String entityVersion;
+
+    private BankAccount bankAccount;
+
+    @BeforeTest
+    public void init() {
+        id = "id";
+        name = "name";
+        created = new Date(1220227200);
+        updated = new Date(1220832000);
+        inputType = BankAccountInputTypeEnum.KEYED;
+        routingNumber = "12311";
+        accountNumber = "123123123";
+        accountType = AccountType.PERSONAL_CHECKING;
+        phone = "5871231234";
+        defaultValue = true;
+        country = "country";
+        bankCode = "1221";
+        entityId = "entityId";
+        entityType = "entityType";
+        entityVersion = "entityVersion";
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        bankAccount = new BankAccount.Builder()
+                .id(id)
+                .name(name)
+                .created(created)
+                .updated(updated)
+                .inputType(inputType)
+                .routingNumber(routingNumber)
+                .accountNumber(accountNumber)
+                .accountType(accountType)
+                .phone(phone)
+                .defaultValue(defaultValue)
+                .country(country)
+                .bankCode(bankCode)
+                .entityId(entityId)
+                .entityType(entityType)
+                .entityVersion(entityVersion)
+                .build();
+
+    }
+
+    @Test
+    public void testAllGetters() {
+        Assert.assertEquals(bankAccount.getId(), id);
+        Assert.assertEquals(bankAccount.getName(), name);
+        Assert.assertEquals(bankAccount.getCreated(), created);
+        Assert.assertEquals(bankAccount.getUpdated(), updated);
+        Assert.assertEquals(bankAccount.getInputType(), inputType);
+        Assert.assertEquals(bankAccount.getRoutingNumber(), routingNumber);
+        Assert.assertEquals(bankAccount.getAccountNumber(), accountNumber);
+        Assert.assertEquals(bankAccount.getPhone(), phone);
+        Assert.assertEquals(bankAccount.getDefaultValue(), defaultValue);
+        Assert.assertEquals(bankAccount.getCountry(), country);
+        Assert.assertEquals(bankAccount.getBankCode(), bankCode);
+        Assert.assertEquals(bankAccount.getEntityId(), entityId);
+        Assert.assertEquals(bankAccount.getEntityType(), entityType);
+        Assert.assertEquals(bankAccount.getEntityVersion(), entityVersion);
+    }
+
+    @Test
+    public void testAllSetters() {
+        String newId = "new id";
+        String newName = "new name";
+        Date newCreated = new Date(1220832000);
+        Date newUpdated = new Date(1220227200);
+        // set to null because there is no second option
+        BankAccountInputTypeEnum newInputType = null;
+        String newRoutingNumber = "11321";
+        String newAccountNumber = "45655623";
+        AccountType newAccountType = AccountType.PERSONAL_SAVINGS;
+        String newPhone = "1231231231";
+        Boolean newDefaultValue = false;
+        String newCountry = "new country";
+        String newBankCode = "1234";
+        String newEntityId = "new entityId";
+        String newEntityType = "new entityType";
+        String newEntityVersion = "new entityVersion";
+
+        bankAccount.setId(newId);
+        bankAccount.setName(newName);
+        bankAccount.setCreated(newCreated);
+        bankAccount.setUpdated(newUpdated);
+        bankAccount.setInputType(newInputType);
+        bankAccount.setRoutingNumber(newRoutingNumber);
+        bankAccount.setAccountNumber(newAccountNumber);
+        bankAccount.setAccountType(newAccountType);
+        bankAccount.setPhone(newPhone);
+        bankAccount.setDefaultValue(newDefaultValue);
+        bankAccount.setCountry(newCountry);
+        bankAccount.setBankCode(newBankCode);
+        bankAccount.setEntityId(newEntityId);
+        bankAccount.setEntityType(newEntityType);
+        bankAccount.setEntityVersion(newEntityVersion);
+
+        Assert.assertEquals(bankAccount.getId(), newId);
+        Assert.assertEquals(bankAccount.getName(), newName);
+        Assert.assertEquals(bankAccount.getCreated(), newCreated);
+        Assert.assertEquals(bankAccount.getUpdated(), newUpdated);
+        Assert.assertEquals(bankAccount.getInputType(), newInputType);
+        Assert.assertEquals(bankAccount.getRoutingNumber(), newRoutingNumber);
+        Assert.assertEquals(bankAccount.getAccountNumber(), newAccountNumber);
+        Assert.assertEquals(bankAccount.getPhone(), newPhone);
+        Assert.assertEquals(bankAccount.getDefaultValue(), newDefaultValue);
+        Assert.assertEquals(bankAccount.getCountry(), newCountry);
+        Assert.assertEquals(bankAccount.getBankCode(), newBankCode);
+        Assert.assertEquals(bankAccount.getEntityId(), newEntityId);
+        Assert.assertEquals(bankAccount.getEntityType(), newEntityType);
+        Assert.assertEquals(bankAccount.getEntityVersion(), newEntityVersion);
+    }
+
+    @Test
+    public void testToString() {
+        // Since we cant mock ReflectionToStringBuilder without powermock, just check if it includes below
+        String expectedResult = "[id=id,name=name,created=Wed Jan 14 19:57:07 MST 1970,updated=Wed Jan 14 20:07:12 MST 1970,inputType=KEYED,routingNumber=12311,accountNumber=123123123,accountType=PERSONAL_CHECKING,phone=5871231234,defaultValue=true,country=country,bankCode=1221,entityId=entityId,entityType=entityType,entityVersion=entityVersion,intuit_tid=<null>,requestId=<null>]";
+        String actualResult = bankAccount.toString();
+        Assert.assertTrue(actualResult.contains(expectedResult));
+    }
+}

--- a/payments-api/src/test/java/com/intuit/payment/util/JsonUtilTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/util/JsonUtilTest.java
@@ -51,7 +51,7 @@ public class JsonUtilTest {
 	}
 
 	@Test
-	public void testNullSerialization() throws SerializationException {
+	public void testNullSerialize() throws SerializationException {
 		String cardStr = JsonUtil.serialize(null);
 		Assert.assertNull(cardStr);
 	}

--- a/payments-api/src/test/java/com/intuit/payment/util/JsonUtilTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/util/JsonUtilTest.java
@@ -42,26 +42,12 @@ public class JsonUtilTest {
 	}
 
 	@Test
-	public void testSerialize() throws SerializationException{			
+	public void testSerialize() throws SerializationException {
 		Card card = new Card.Builder().number("12345").build();
 		String cardStr = JsonUtil.serialize(card);
 		Assert.assertNotNull(cardStr);
 		String result = "{\n  \"number\" : \"12345\"\n}";
 		Assert.assertEquals(cardStr, result);
-	}
-
-	@Test
-    public void testDeserialize() throws SerializationException {
-        String cardStr = "{\"number\":\"12345\"}";
-        Card card = (Card) JsonUtil.deserialize(cardStr,  new TypeReference<Card>() {} );
-        Assert.assertEquals(card.getNumber(), "12345");
-    }
-
-    @Test(expectedExceptions = SerializationException.class)
-	public void testErrorSerialize() throws SerializationException{
-		// Serializing this causes a InvalidDefinitionException to be thrown
-		ClassWithPrivateFields classWithPrivateFields = new ClassWithPrivateFields(1, "John");
-		JsonUtil.serialize(classWithPrivateFields);
 	}
 
 	@Test
@@ -71,11 +57,25 @@ public class JsonUtilTest {
 	}
 
 	@Test(expectedExceptions = SerializationException.class)
-	public void testErrorDeserialize() throws SerializationException{
+	public void testErrorSerialize() throws SerializationException {
+		// Serializing this causes a InvalidDefinitionException to be thrown
+		ClassWithPrivateFields classWithPrivateFields = new ClassWithPrivateFields(1, "John");
+		JsonUtil.serialize(classWithPrivateFields);
+	}
+
+	@Test
+    public void testDeserialize() throws SerializationException {
+        String cardStr = "{\"number\":\"12345\"}";
+        Card card = (Card) JsonUtil.deserialize(cardStr,  new TypeReference<Card>() {} );
+        Assert.assertEquals(card.getNumber(), "12345");
+    }
+
+	@Test(expectedExceptions = SerializationException.class)
+	public void testErrorDeserialize() throws SerializationException {
 		String cardStr = "{\"number\":\"12345\"\"}";
 		JsonUtil.deserialize(cardStr,  new TypeReference<Card>() {} );
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	@Test
     public void testDeserializeList() throws SerializationException {

--- a/payments-api/src/test/java/com/intuit/payment/util/JsonUtilTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/util/JsonUtilTest.java
@@ -30,7 +30,16 @@ import com.intuit.payment.exception.SerializationException;
  *
  */
 public class JsonUtilTest {
-	
+
+	// Test class used to ensure exception is thrown inside of JsonUtil
+	public class ClassWithPrivateFields {
+		ClassWithPrivateFields(int id, String name){
+			id = id;
+			name = name;
+		}
+		int id;
+		String name;
+	}
 
 	@Test
 	public void testSerialize() throws SerializationException{			
@@ -40,13 +49,32 @@ public class JsonUtilTest {
 		String result = "{\n  \"number\" : \"12345\"\n}";
 		Assert.assertEquals(cardStr, result);
 	}
-	
+
 	@Test
     public void testDeserialize() throws SerializationException {
         String cardStr = "{\"number\":\"12345\"}";
         Card card = (Card) JsonUtil.deserialize(cardStr,  new TypeReference<Card>() {} );
         Assert.assertEquals(card.getNumber(), "12345");
     }
+
+    @Test(expectedExceptions = SerializationException.class)
+	public void testErrorSerialize() throws SerializationException{
+		// Serializing this causes a InvalidDefinitionException to be thrown
+		ClassWithPrivateFields classWithPrivateFields = new ClassWithPrivateFields(1, "John");
+		JsonUtil.serialize(classWithPrivateFields);
+	}
+
+	@Test
+	public void testNullSerialization() throws SerializationException {
+		String cardStr = JsonUtil.serialize(null);
+		Assert.assertNull(cardStr);
+	}
+
+	@Test(expectedExceptions = SerializationException.class)
+	public void testErrorDeserialize() throws SerializationException{
+		String cardStr = "{\"number\":\"12345\"\"}";
+		JsonUtil.deserialize(cardStr,  new TypeReference<Card>() {} );
+	}
 	
 	@SuppressWarnings("unchecked")
 	@Test
@@ -57,5 +85,5 @@ public class JsonUtilTest {
         Assert.assertEquals(cards.get(0).getNumber(), "12345");
     }
 
-  
+
 }


### PR DESCRIPTION
Add tests for Address and BankAccount models in payments-api. Will try to add more for https://github.com/intuit/QuickBooks-V3-Java-SDK/issues/60