### PR TITLE
#hacktoberfest SerializeInterceptor - Unit Tests Coverage and Bug Fix

### DIFF
--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/SerializeInterceptor.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/SerializeInterceptor.java
@@ -202,7 +202,7 @@ public class SerializeInterceptor implements Interceptor {
 	 */
 	private String getMime(String name, String delimiter) {
 		if (StringUtils.hasText(name)) {
-			return name.substring(name.lastIndexOf(delimiter), name.length());
+			return name.substring(name.lastIndexOf(delimiter) + 1, name.length());
 		}
 		return null;
 	}


### PR DESCRIPTION
Issue #60 -- Increased Code Coverage.
Fixed a bug where file mime returned always included delimiter. 
Refactored and added unit tests.