### PR TITLE
Adding Unit Tests for Payments API Services

### DIFF
--- a/payments-api/src/test/java/com/intuit/payment/services/ECheckServiceTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/services/ECheckServiceTest.java
@@ -1,0 +1,229 @@
+package com.intuit.payment.services;
+
+import com.intuit.payment.config.RequestContext;
+import com.intuit.payment.data.BankAccount;
+import com.intuit.payment.data.Card;
+import com.intuit.payment.data.ECheck;
+import com.intuit.payment.data.Refund;
+import com.intuit.payment.data.Token;
+import com.intuit.payment.exception.BaseException;
+import com.intuit.payment.http.Request;
+import com.intuit.payment.http.Response;
+import com.intuit.payment.services.base.ServiceBase;
+import com.intuit.payment.util.JsonUtil;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+
+public class ECheckServiceTest {
+
+    @Mocked
+    private ServiceBase serviceBase;
+
+    @Test
+    public void testECheckServiceCreation() {
+        ECheckService eCheckService = new ECheckService();
+        Assert.assertNull(eCheckService.getRequestContext());
+    }
+    @Test
+    public void testECheckServiceRequestContext() {
+        RequestContext requestContext = new RequestContext();
+        requestContext.setBaseUrl("fakeBaseUrl");
+        ECheckService eCheckService = new ECheckService(requestContext);
+        Assert.assertEquals(requestContext, eCheckService.getRequestContext());
+
+        RequestContext secondRequestContext = new RequestContext();
+        secondRequestContext.setBaseUrl("secondBaseUrl");
+        eCheckService.setRequestContext(secondRequestContext);
+        Assert.assertEquals(secondRequestContext, eCheckService.getRequestContext());
+    }
+
+    @Test
+    public void testCreateECheck() throws BaseException {
+        ECheck expectedECheck = new ECheck.Builder().id("ijids").amount(new BigDecimal("50000")).build();
+        final String eCheckString = JsonUtil.serialize(expectedECheck);
+        final Response mockedResponse = new Response(200, eCheckString, "fjkdlsfd");
+        mockedResponse.setResponseObject(expectedECheck);
+
+        new Expectations() {{
+            serviceBase.sendRequest((Request) any); result = mockedResponse;
+        }};
+
+        RequestContext requestContext = new RequestContext();
+        requestContext.setBaseUrl("fakeBaseUrl");
+        ECheckService eCheckService = new ECheckService(requestContext);
+
+        try {
+            ECheck eCheck = new ECheck();
+            ECheck eCheckGenerated = eCheckService.create(eCheck);
+            Assert.assertEquals(expectedECheck, eCheckGenerated);
+
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRetrieveECheck() throws BaseException {
+        ECheck expectedECheck = new ECheck.Builder().id("ijids").amount(new BigDecimal("50000")).build();
+        final String eCheckString = JsonUtil.serialize(expectedECheck);
+        final Response mockedResponse = new Response(200, eCheckString, "fjkdlsfd");
+        mockedResponse.setResponseObject(expectedECheck);
+
+        new Expectations() {{
+            serviceBase.sendRequest((Request) any); result = mockedResponse;
+        }};
+
+        RequestContext requestContext = new RequestContext();
+        requestContext.setBaseUrl("fakeBaseUrl");
+        ECheckService eCheckService = new ECheckService(requestContext);
+
+        try {
+            ECheck eCheckGenerated = eCheckService.retrieve("myECheckId");
+            Assert.assertEquals(expectedECheck, eCheckGenerated);
+
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRetrieveECheckNullECheckId() {
+        ECheckService eCheckService = new ECheckService();
+        try {
+            eCheckService.retrieve(null);
+            Assert.fail("Expected IllegalArgumentException thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(true, "Expected IllegalArgumentException was thrown");
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+        try {
+            eCheckService.retrieve("");
+            Assert.fail("Expected IllegalArgumentException thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(true, "Expected IllegalArgumentException was thrown");
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRefundECheck() throws BaseException {
+        Refund expectedRefund = new Refund.Builder().id("ijids").amount(new BigDecimal("50000")).build();
+        final String eCheckString = JsonUtil.serialize(expectedRefund);
+        final Response mockedResponse = new Response(200, eCheckString, "fjkdlsfd");
+        mockedResponse.setResponseObject(expectedRefund);
+
+        new Expectations() {{
+            serviceBase.sendRequest((Request) any); result = mockedResponse;
+        }};
+
+        RequestContext requestContext = new RequestContext();
+        requestContext.setBaseUrl("fakeBaseUrl");
+        ECheckService eCheckService = new ECheckService(requestContext);
+
+        try {
+            Refund refund = new Refund.Builder().id("refundId").type("type").build();
+            Refund refundGenerated = eCheckService.refund("myECheckId", refund);
+            Assert.assertEquals(expectedRefund, refundGenerated);
+
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRefundNullECheckId() {
+        ECheckService eCheckService = new ECheckService();
+        Refund refund = new Refund();
+        try {
+            eCheckService.refund(null, refund);
+            Assert.fail("Expected IllegalArgumentException thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(true, "Expected IllegalArgumentException was thrown");
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+        try {
+            eCheckService.refund("", refund);
+            Assert.fail("Expected IllegalArgumentException thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(true, "Expected IllegalArgumentException was thrown");
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetRefund() throws BaseException {
+        Refund expectedRefund = new Refund.Builder().id("ijids").amount(new BigDecimal("50000")).build();
+        final String eCheckString = JsonUtil.serialize(expectedRefund);
+        final Response mockedResponse = new Response(200, eCheckString, "fjkdlsfd");
+        mockedResponse.setResponseObject(expectedRefund);
+
+        new Expectations() {{
+            serviceBase.sendRequest((Request) any); result = mockedResponse;
+        }};
+
+        RequestContext requestContext = new RequestContext();
+        requestContext.setBaseUrl("fakeBaseUrl");
+        ECheckService eCheckService = new ECheckService(requestContext);
+
+        try {
+            Refund refund = new Refund.Builder().id("refundId").type("type").build();
+            Refund refundGenerated = eCheckService.getRefund("myECheckId", "myRefundId");
+            Assert.assertEquals(expectedRefund, refundGenerated);
+
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRefundECheckNullCheckId() {
+        ECheckService eCheckService = new ECheckService();
+        try {
+            eCheckService.getRefund(null, "refundid");
+            Assert.fail("Expected IllegalArgumentException thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(true, "Expected IllegalArgumentException was thrown");
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+        try {
+            eCheckService.getRefund("", "refundid");
+            Assert.fail("Expected IllegalArgumentException thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(true, "Expected IllegalArgumentException was thrown");
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRefundECheckNullRefundId() {
+        ECheckService eCheckService = new ECheckService();
+        try {
+            eCheckService.getRefund("echeckid", null);
+            Assert.fail("Expected IllegalArgumentException thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(true, "Expected IllegalArgumentException was thrown");
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+        try {
+            eCheckService.getRefund("echeckid", "");
+            Assert.fail("Expected IllegalArgumentException thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(true, "Expected IllegalArgumentException was thrown");
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+    }
+
+
+}

--- a/payments-api/src/test/java/com/intuit/payment/services/ECheckServiceTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/services/ECheckServiceTest.java
@@ -1,11 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.payment.services;
 
 import com.intuit.payment.config.RequestContext;
-import com.intuit.payment.data.BankAccount;
-import com.intuit.payment.data.Card;
 import com.intuit.payment.data.ECheck;
 import com.intuit.payment.data.Refund;
-import com.intuit.payment.data.Token;
 import com.intuit.payment.exception.BaseException;
 import com.intuit.payment.http.Request;
 import com.intuit.payment.http.Response;

--- a/payments-api/src/test/java/com/intuit/payment/services/TokenServiceTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/services/TokenServiceTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.payment.services;
 
 import com.intuit.payment.config.RequestContext;

--- a/payments-api/src/test/java/com/intuit/payment/services/TokenServiceTest.java
+++ b/payments-api/src/test/java/com/intuit/payment/services/TokenServiceTest.java
@@ -1,0 +1,91 @@
+package com.intuit.payment.services;
+
+import com.intuit.payment.config.RequestContext;
+import com.intuit.payment.data.BankAccount;
+import com.intuit.payment.data.Card;
+import com.intuit.payment.data.Token;
+import com.intuit.payment.exception.BaseException;
+import com.intuit.payment.http.Request;
+import com.intuit.payment.http.Response;
+import com.intuit.payment.services.base.ServiceBase;
+import com.intuit.payment.util.JsonUtil;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TokenServiceTest {
+
+    @Mocked
+    private ServiceBase serviceBase;
+
+    @Test
+    public void testTokenServiceCreation() {
+        TokenService tokenService = new TokenService();
+        Assert.assertNull(tokenService.getRequestContext());
+    }
+    @Test
+    public void testTokenServiceRequestContext() {
+        RequestContext requestContext = new RequestContext();
+        requestContext.setBaseUrl("fakeBaseUrl");
+        TokenService tokenService = new TokenService(requestContext);
+        Assert.assertEquals(requestContext, tokenService.getRequestContext());
+
+        RequestContext secondRequestContext = new RequestContext();
+        secondRequestContext.setBaseUrl("secondBaseUrl");
+        tokenService.setRequestContext(secondRequestContext);
+        Assert.assertEquals(secondRequestContext, tokenService.getRequestContext());
+
+    }
+
+    @Test
+    public void testCreateToken() throws BaseException {
+        Token expectedToken = new Token.Builder()
+                .card(new Card.Builder().name("cardName").build())
+                .bankAccount(new BankAccount.Builder().id("fakeID").build())
+                .value("fake value")
+                .build();
+        final String tokenString = JsonUtil.serialize(expectedToken);
+        final Response mockedResponse = new Response(200, tokenString, "fjkdlsfd");
+        mockedResponse.setResponseObject(expectedToken);
+
+        new Expectations() {{
+            serviceBase.sendRequest((Request) any); result = mockedResponse;
+        }};
+
+        RequestContext requestContext = new RequestContext();
+        requestContext.setBaseUrl("fakeBaseUrl");
+        TokenService tokenService = new TokenService(requestContext);
+
+        try {
+            Token token = new Token();
+            Token tokenGenerated = tokenService.createToken(token);
+            Assert.assertEquals(expectedToken, tokenGenerated);
+
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateTokenBadResponse() throws BaseException {
+        final Response mockedResponse = new Response(500, "", "fjkdlsfd");
+        new Expectations() {{
+            serviceBase.sendRequest((Request) any); result = mockedResponse;
+        }};
+
+        RequestContext requestContext = new RequestContext();
+        requestContext.setBaseUrl("fakeBaseUrl");
+        TokenService tokenService = new TokenService(requestContext);
+
+        try {
+            Token token = new Token();
+            Token tokenGenerated = tokenService.createToken(token);
+            Assert.assertNull(tokenGenerated);
+
+        } catch (BaseException e) {
+            Assert.fail("Unexpected BaseException thrown " + e.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
Increasing code coverage for 
- ECheckService
- TokenService

This is for issue #60
