### PR TITLE
fix dependency conflict issue

### DIFF
--- a/ipp-v3-java-devkit/pom.xml
+++ b/ipp-v3-java-devkit/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>commons-io</artifactId>
             <version>2.5</version>
         </dependency>
+	<dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.11</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>


### PR DESCRIPTION
[#143 ](https://github.com/intuit/QuickBooks-V3-Java-SDK/issues/143) dependency conflict issue for commons-codec:commons-codec:jar