### PR TITLE
BDC-70000 Fix null pointer exception

### DIFF
--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HandleResponseInterceptor.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HandleResponseInterceptor.java
@@ -104,19 +104,19 @@ public class HandleResponseInterceptor implements Interceptor {
 		if (intuitResponse != null && intuitResponse.getFault() != null) {
 			Fault fault = intuitResponse.getFault();
 
-			if (fault.getType().equalsIgnoreCase("Validation")) {
+			if ("Validation".equalsIgnoreCase(fault.getType())) {
 				throw new ValidationException(fault.getError());
-			} else if (fault.getType().equalsIgnoreCase("Service")) {
+			} else if ("Service".equalsIgnoreCase(fault.getType())) {
 				throw new ServiceException(fault.getError());
-			} else if (fault.getType().equalsIgnoreCase("AuthenticationFault")) {
+			} else if ("AuthenticationFault".equalsIgnoreCase(fault.getType())) {
 				throw new AuthenticationException(fault.getError());
-			} else if (fault.getType().equalsIgnoreCase("Authentication")) {
+			} else if ("Authentication".equalsIgnoreCase(fault.getType())) {
 				throw new AuthenticationException(fault.getError());
-			} else if (fault.getType().equalsIgnoreCase("ApplicationAuthenticationFailed")) {
+			} else if ("ApplicationAuthenticationFailed".equalsIgnoreCase(fault.getType())) {
 				throw new AuthenticationException(fault.getError());
-			} else if (fault.getType().equalsIgnoreCase("Authorization")) {
+			} else if ("Authorization".equalsIgnoreCase(fault.getType())) {
 				throw new AuthorizationException(fault.getError());
-			} else if (fault.getType().equalsIgnoreCase("AuthorizationFault")) {
+			} else if ("AuthorizationFault".equalsIgnoreCase(fault.getType())) {
 				throw new AuthorizationException(fault.getError());
 			} else {
 				//not able to recognize the type of exception


### PR DESCRIPTION
BillDotCom got a null pointer exception thrown from QBO SDK. It appears that the fault.getType() return Null and access equalsIgnoreCase throw Null Pointer Exception.

```java
Caused by: java.lang.NullPointerException: null
	at com.intuit.ipp.interceptors.HandleResponseInterceptor.execute(HandleResponseInterceptor.java:107)
	at com.intuit.ipp.interceptors.IntuitInterceptorProvider.executeResponseInterceptors(IntuitInterceptorProvider.java:114)
	at com.intuit.ipp.interceptors.IntuitInterceptorProvider.executeInterceptors(IntuitInterceptorProvider.java:87)
	at com.intuit.ipp.services.DataService.executeInterceptors(DataService.java:159)
	at com.intuit.ipp.services.DataService.executeCDCQuery(DataService.java:672)
```