### PR TITLE
Excluding commons-beanutils-core from commons-collections dependency

### DIFF
--- a/ipp-v3-java-devkit/pom.xml
+++ b/ipp-v3-java-devkit/pom.xml
@@ -90,6 +90,10 @@
           <groupId>commons-beanutils</groupId>
           <artifactId>commons-beanutils</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils-core</artifactId>
+        </exclusion>
       </exclusions> 
     </dependency>  
     <!-- https://mvnrepository.com/artifact/commons-collections/commons-collections -->  


### PR DESCRIPTION
Solution for issue: **Exclude the wrong library #201**

My initial investigation of the dependency tree shows that `commons-configuration` library used `commons-beanutils-core`:
```
[INFO] +- commons-configuration:commons-configuration:jar:1.6:compile
[INFO] |  +- commons-lang:commons-lang:jar:2.4:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.1.1:compile
[INFO] |  +- commons-digester:commons-digester:jar:1.8:compile
[INFO] |  \- commons-beanutils:commons-beanutils-core:jar:1.8.0:compile
```
Hence excluding `commons-beanutils-core` from the same.