### PR TITLE
Update org.apache.httpcomponents from 4.5.x to 5.x.x

### DIFF
--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HandleResponseInterceptor.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HandleResponseInterceptor.java
@@ -15,7 +15,6 @@
  *******************************************************************************/
 package com.intuit.ipp.interceptors;
 
-import org.apache.http.StatusLine;
 
 import com.intuit.ipp.data.EntitlementsResponse;
 import com.intuit.ipp.data.Fault;
@@ -32,6 +31,7 @@ import com.intuit.ipp.exception.ServiceException;
 import com.intuit.ipp.exception.ServiceUnavailableException;
 import com.intuit.ipp.exception.ValidationException;
 import com.intuit.ipp.util.Logger;
+import org.apache.hc.core5.http.message.StatusLine;
 
 /**
  * Interceptor to handle Http response. 

--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/ResponseElements.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/ResponseElements.java
@@ -17,7 +17,7 @@ package com.intuit.ipp.interceptors;
 
 import java.io.InputStream;
 
-import org.apache.http.StatusLine;
+import org.apache.hc.core5.http.message.StatusLine;
 
 import com.intuit.ipp.core.Response;
 import com.intuit.ipp.services.CallbackMessage;

--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/security/IAuthorizer.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/security/IAuthorizer.java
@@ -23,9 +23,9 @@
 package com.intuit.ipp.security;
 
 import java.net.HttpURLConnection;
-import org.apache.http.client.methods.HttpRequestBase;
 
 import com.intuit.ipp.exception.FMSException;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 
 /**
  * Interface for Authorizer
@@ -38,7 +38,7 @@ public interface IAuthorizer {
 	 * @param httpRequest
 	 * @throws FMSException
 	 */
-	void authorize(HttpRequestBase httpRequest) throws FMSException;
+	void authorize(HttpUriRequestBase httpRequest) throws FMSException;
 	/**
 	 * Authorize a http url connection using Signpost
 	 * @param httpUrlConnection

--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/security/OAuth2Authorizer.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/security/OAuth2Authorizer.java
@@ -2,9 +2,8 @@ package com.intuit.ipp.security;
 
 import java.net.HttpURLConnection;
 
-import org.apache.http.client.methods.HttpRequestBase;
-
 import com.intuit.ipp.exception.FMSException;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 
 /**
  * This class will sign the http request using oAuth2 credentials
@@ -14,7 +13,7 @@ public class OAuth2Authorizer implements IAuthorizer {
 	private String accessToken;
 
 	@Override
-	public void authorize(HttpRequestBase httpRequest) throws FMSException {
+	public void authorize(HttpUriRequestBase httpRequest) throws FMSException {
 		httpRequest.setHeader("Authorization", "Bearer " + accessToken);
 	}
 	

--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/security/OAuthAuthorizer.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/security/OAuthAuthorizer.java
@@ -24,12 +24,11 @@ import oauth.signpost.exception.OAuthExpectationFailedException;
 import oauth.signpost.exception.OAuthMessageSignerException;
 import oauth.signpost.signature.AuthorizationHeaderSigningStrategy;
 
-import org.apache.http.client.methods.HttpRequestBase;
-
 import com.intuit.ipp.exception.FMSException;
 import com.intuit.ipp.interceptors.HTTPURLConnectionInterceptor;
 import com.intuit.ipp.util.Config;
 import com.intuit.ipp.util.StringUtils;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 
 /**
  * This class will sign the http request using oAuth credentials
@@ -45,7 +44,7 @@ public class OAuthAuthorizer implements IAuthorizer {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void authorize(HttpRequestBase httpRequest) throws FMSException {
+	public void authorize(HttpUriRequestBase httpRequest) throws FMSException {
 		try {
 			oAuthConsumer.sign(httpRequest);
 		} catch (OAuthMessageSignerException e) {

--- a/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/data/EntityTest.java
+++ b/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/data/EntityTest.java
@@ -18,24 +18,23 @@ package com.intuit.ipp.data;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
-import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpVersion;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.conn.params.ConnRoutePNames;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.params.CoreProtocolPNames;
+import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpVersion;
 
 import com.intuit.ipp.core.IEntity;
 import com.intuit.ipp.data.Customer;
 import com.intuit.ipp.data.IntuitResponse;
 import com.intuit.ipp.extra.SerializeXML;
 import com.intuit.ipp.util.Logger;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 
 public class EntityTest {
 	
@@ -73,17 +72,16 @@ public class EntityTest {
 		try {
 			StringEntity bodyDataEntity = new StringEntity(bodyData);
 			httpPost.setEntity(bodyDataEntity);
-			httpPost.setProtocolVersion(HttpVersion.HTTP_1_0);
-		
-			HttpResponse response = httpclient.execute(httpPost);
-			
-			BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
-			StringBuilder builder = new StringBuilder();
-			for (String line = null; (line = reader.readLine()) != null;) {
-			    builder.append(line).append("\n");
-			}
-			LOG.debug(builder.toString());
-			return builder.toString();
+
+			return httpclient.execute(httpPost, response -> {
+				BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8));
+				StringBuilder builder = new StringBuilder();
+				for (String line = null; (line = reader.readLine()) != null;) {
+					builder.append(line).append("\n");
+				}
+				LOG.debug(builder.toString());
+				return builder.toString();
+			});
 		} catch (ClientProtocolException e) {
 			e.printStackTrace();
 		} catch (IOException e) {

--- a/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/net/RetryPolicyHandlerTest.java
+++ b/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/net/RetryPolicyHandlerTest.java
@@ -15,11 +15,14 @@
  *******************************************************************************/
 package com.intuit.ipp.net;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
+import com.intuit.ipp.data.Status;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.HttpResponse;
 import java.net.ConnectException;
-import org.apache.http.impl.client.HttpClientBuilder;
+
+import org.apache.hc.core5.http.message.StatusLine;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -71,9 +74,9 @@ public class RetryPolicyHandlerTest {
 	@Test(expectedExceptions = ConnectException.class)
 	public void testFixedRetry() throws Exception {
 		handler = new IntuitRetryPolicyHandler(retryCount, retryInterval);
-		client = HttpClientBuilder.create().setRetryHandler(handler).build();
-		HttpResponse x = client.execute(httpget);
-		LOG.debug(x.getStatusLine().toString());
+		client = HttpClientBuilder.create().setRetryStrategy(handler).build();
+		String status = client.execute(httpget, response -> new StatusLine(response).toString());
+		LOG.debug(status);
 	}
 
 	/**
@@ -85,9 +88,9 @@ public class RetryPolicyHandlerTest {
 	public void testIncrementalRetry() throws Exception {
 		LOG.debug("in incremental");
 		handler = new IntuitRetryPolicyHandler(retryCount, retryInterval, increment);
-		client = HttpClientBuilder.create().setRetryHandler(handler).build();
-		HttpResponse resp = client.execute(httpget);
-		LOG.debug(resp.getStatusLine().toString());
+		client = HttpClientBuilder.create().setRetryStrategy(handler).build();
+		String status = client.execute(httpget, response -> new StatusLine(response).toString());
+		LOG.debug(status);
 	}
 
 	/**
@@ -100,9 +103,9 @@ public class RetryPolicyHandlerTest {
 	public void testExponentialRetry() throws Exception {
 		LOG.debug("in exponential");
 		handler = new IntuitRetryPolicyHandler(retryCount, minBackoff, maxBackoff, deltaBackoff);
-		client = HttpClientBuilder.create().setRetryHandler(handler).build();
-		HttpResponse resp = client.execute(httpget);
-		LOG.debug(resp.getStatusLine().toString());
+		client = HttpClientBuilder.create().setRetryStrategy(handler).build();
+		String status = client.execute(httpget, response -> new StatusLine(response).toString());
+		LOG.debug(status);
 	}
 
 	/**

--- a/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/security/OAuth2AuthorizerTest.java
+++ b/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/security/OAuth2AuthorizerTest.java
@@ -19,9 +19,9 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 
-import org.apache.http.Header;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.core5.http.Header;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -35,7 +35,7 @@ public class OAuth2AuthorizerTest {
 	private final String URL_STRING = "http://code.intuit.com";
 
 	public String extractHeaderParams(Header[] header,
-			HttpRequestBase requestBase) {
+			HttpUriRequestBase requestBase) {
 
 		String value = null;
 		if (header != null)
@@ -64,13 +64,12 @@ public class OAuth2AuthorizerTest {
 
 		String accessToken = "TestAccessToken";
 		Header[] header = null;
-		HttpRequestBase requestBase = new HttpGet();
+		HttpUriRequestBase requestBase = new HttpGet(URL_STRING);
 		try {
-			requestBase.setURI(new URI(URL_STRING));
 			OAuth2Authorizer oauthAuthorizer = new OAuth2Authorizer(accessToken);
 			oauthAuthorizer.authorize(requestBase);
 
-			header = requestBase.getAllHeaders();
+			header = requestBase.getHeaders();
 			Assert.assertEquals("Bearer "+accessToken,extractHeaderParams(header, requestBase));
 			
 

--- a/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/security/OAuthAuthorizerTest.java
+++ b/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/security/OAuthAuthorizerTest.java
@@ -19,9 +19,9 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 
-import org.apache.http.Header;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.core5.http.Header;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -35,7 +35,7 @@ public class OAuthAuthorizerTest {
 	private final String URL_STRING = "http://code.intuit.com";
 
 	public String extractHeaderParams(Header[] header,
-			HttpRequestBase requestBase, String headerName) {
+									  HttpUriRequestBase requestBase, String headerName) {
 
 		String[] headerArray = null;
 		String[] headerItemArray = null;
@@ -68,14 +68,13 @@ public class OAuthAuthorizerTest {
 		String consumerKey = "TestConsumerKey";
 		String consumerSecret = "TestConsumerSecret";
 		Header[] header = null;
-		HttpRequestBase requestBase = new HttpGet();
+		HttpUriRequestBase requestBase = new HttpGet(URL_STRING);
 		try {
-			requestBase.setURI(new URI(URL_STRING));
 			OAuthAuthorizer oauthAuthorizer = new OAuthAuthorizer(consumerKey,
 					consumerSecret, accessToken, accessTokenSecret);
 			oauthAuthorizer.authorize(requestBase);
 
-			header = requestBase.getAllHeaders();
+			header = requestBase.getHeaders();
 			Assert.assertEquals(
 					accessToken,
 					extractHeaderParams(header, requestBase,

--- a/oauth2-platform-api/src/main/java/com/intuit/oauth2/client/OAuth2PlatformClient.java
+++ b/oauth2-platform-api/src/main/java/com/intuit/oauth2/client/OAuth2PlatformClient.java
@@ -28,8 +28,8 @@ import java.util.List;
 
 import com.intuit.oauth2.exception.InvalidRequestException;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.http.NameValuePair;
-import org.apache.http.message.BasicNameValuePair;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/oauth2-platform-api/src/main/java/com/intuit/oauth2/http/Request.java
+++ b/oauth2-platform-api/src/main/java/com/intuit/oauth2/http/Request.java
@@ -21,7 +21,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 
-import org.apache.http.NameValuePair;
+import org.apache.hc.core5.http.NameValuePair;
 
 import com.intuit.oauth2.exception.InvalidRequestException;
 

--- a/oauth2-platform-api/src/main/java/com/intuit/oauth2/http/Response.java
+++ b/oauth2-platform-api/src/main/java/com/intuit/oauth2/http/Response.java
@@ -15,10 +15,7 @@
  *******************************************************************************/
 package com.intuit.oauth2.http;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 
 import org.slf4j.Logger;
 
@@ -33,18 +30,18 @@ import com.intuit.oauth2.utils.LoggerImpl;
  */
 public class Response {
 	
-	private final InputStream stream;
+	private final byte[] bytes;
     private final int statusCode;
     private String content;
     private final String intuit_tid;
     
     private static final Logger logger = LoggerImpl.getInstance();
-    
-	public Response(final InputStream stream, final int statusCode, final String intuit_tid) {
-        this.stream = stream;
-        this.statusCode = statusCode;
-        this.intuit_tid = intuit_tid;
-    }
+
+	public Response(final InputStream inputStream, final int statusCode, final String intuit_tid) throws IOException {
+		this.bytes = inputStream != null ? inputStream.readAllBytes() : new byte[0];
+		this.statusCode = statusCode;
+		this.intuit_tid = intuit_tid;
+	}
 	
     /**
      * Returns the json content from http response
@@ -55,27 +52,16 @@ public class Response {
     public String getContent() throws ConnectionException {
     	
     	logger.debug("Enter Response::getContent");	
-    	
+
     	if (content != null) {
     		logger.debug("content already available ");
     		logger.debug("Response json : " + content);
             return content;
         }
 
-    	BufferedReader rd = new BufferedReader(new InputStreamReader(stream));
-		StringBuffer result = new StringBuffer();
-		String line = "";
-		try {
-			while ((line = rd.readLine()) != null) {
-			    result.append(line);
-			}
-		} catch (IOException e) {
-			logger.error("Exception while retrieving content", e);
-            throw new ConnectionException(e.getMessage());
-		}
-		content = result.toString();
-		logger.debug("Response json : " + result.toString());
-		logger.debug("End Response::getContent");	
+		content = new String(bytes);
+		logger.debug("Response json : " + content);
+		logger.debug("End Response::getContent");
 		return content;
         
     }
@@ -95,7 +81,7 @@ public class Response {
 	 * @return
 	 */
 	public InputStream getStream() {
-		return stream;
+		return new ByteArrayInputStream(bytes);
 	}
     
 	public String getIntuit_tid() {

--- a/oauth2-platform-api/src/test/java/com/intuit/oauth2/client/OAuth2PlatformClientTest.java
+++ b/oauth2-platform-api/src/test/java/com/intuit/oauth2/client/OAuth2PlatformClientTest.java
@@ -22,10 +22,11 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.http.message.BasicNameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -96,7 +97,7 @@ public class OAuth2PlatformClientTest {
   }
 
   @Test(expectedExceptions = OAuthException.class)
-  public void retrieveBearerTokensThrowsOAuthExceptionOnErrorStatus() throws JsonProcessingException, OAuthException {
+  public void retrieveBearerTokensThrowsOAuthExceptionOnErrorStatus() throws IOException, OAuthException {
     ObjectWriter writer = mapper.writerFor(BearerTokenResponse.class);
     Response mockResponse = new Response(
         IOUtils.toInputStream(writer.writeValueAsString(new BearerTokenResponse()), StandardCharsets.UTF_8), 500, intuit_tid);
@@ -130,7 +131,7 @@ public class OAuth2PlatformClientTest {
   }
 
   @Test(expectedExceptions = OAuthException.class)
-  public void refreshTokenThrowsOAuthExceptionOnErrorStatus() throws JsonProcessingException, OAuthException {
+  public void refreshTokenThrowsOAuthExceptionOnErrorStatus() throws IOException, OAuthException {
     ObjectWriter writer = mapper.writerFor(BearerTokenResponse.class);
     Response mockResponse = new Response(
         IOUtils.toInputStream(writer.writeValueAsString(new BearerTokenResponse()), StandardCharsets.UTF_8), 500, intuit_tid);
@@ -188,7 +189,7 @@ public class OAuth2PlatformClientTest {
   }
 
   @Test(expectedExceptions = OpenIdException.class)
-  public void getUserInfoThrowsOpenIdExceptionOnErrorStatus() throws JsonProcessingException, OpenIdException {
+  public void getUserInfoThrowsOpenIdExceptionOnErrorStatus() throws IOException, OpenIdException {
     ObjectWriter writer = mapper.writerFor(UserInfoResponse.class);
     Response mockResponse = new Response(
         IOUtils.toInputStream(writer.writeValueAsString(new UserInfoResponse()), StandardCharsets.UTF_8), 500, intuit_tid);

--- a/oauth2-platform-api/src/test/java/com/intuit/oauth2/http/ResponseTest.java
+++ b/oauth2-platform-api/src/test/java/com/intuit/oauth2/http/ResponseTest.java
@@ -18,6 +18,7 @@ package com.intuit.oauth2.http;
 import static org.testng.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 
@@ -30,13 +31,14 @@ public class ResponseTest {
 	
 	
 	@Test
-    public void testGetStream() throws UnsupportedEncodingException, ConnectionException {
+    public void testGetStream() throws IOException, ConnectionException {
         
         String content = "frobozz";
-        InputStream istream = new ByteArrayInputStream(content.getBytes("UTF-8"));
+        byte[] bytes = content.getBytes("UTF-8");
+        InputStream istream = new ByteArrayInputStream(bytes);
         String intuit_tid = "abcd-123-xyz";
         Response response = new Response(istream, 200, intuit_tid);
-        assertEquals(istream, response.getStream());
+        assertEquals(bytes, response.getStream().readAllBytes());
         assertEquals(content, response.getContent());
         assertEquals(intuit_tid, response.getIntuit_tid());
     }

--- a/payments-api/src/main/java/com/intuit/payment/services/base/ServiceBase.java
+++ b/payments-api/src/main/java/com/intuit/payment/services/base/ServiceBase.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus;
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,14 @@
             <version>1.7.28</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.3.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.12</version>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>5.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
This updates two dependencies:
1. org.apache.httpcomponents:httpclient:4.5.13 -> org.apache.httpcomponents.client5:httpclient5:5.3.1
2. org.apache.httpcomponents:httpcore:4.4.12 -> org.apache.httpcomponents.core5:httpcore5:5.2.4

There are many breaking changes between the two versions and the imports changed so a lot of files had to be touched.