### PR TITLE
Expose HTTP response headers on FMSException

### DIFF
--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/exception/FMSException.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/exception/FMSException.java
@@ -15,8 +15,11 @@
  *******************************************************************************/
 package com.intuit.ipp.exception;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import com.intuit.ipp.data.Error;
 
 /**
@@ -44,7 +47,13 @@ public class FMSException extends Exception {
 	 * variable intuit_tid
 	 */
 	private String intuit_tid;
-	
+
+	/**
+	 * variable responseHeaders - the headers received on the response that produced this exception,
+	 * keyed case-insensitively
+	 */
+	private Map<String, String> responseHeaders;
+
 	/**
 	 * Constructor FMSException
 	 * 
@@ -118,7 +127,60 @@ public class FMSException extends Exception {
 	public void setIntuit_tid(String intuit_tid) {
 		this.intuit_tid = intuit_tid;
 	}
-	
+
+	/**
+	 * Method to get the headers received on the response that produced this exception.
+	 *
+	 * <p>Keys are case-insensitive. Where a header was repeated, the last value received is
+	 * retained. Returns an empty map rather than null when no headers were captured.
+	 *
+	 * <p>Useful for auth failures, where the {@code WWW-Authenticate} challenge distinguishes
+	 * causes that the response body may not:
+	 *
+	 * <pre>
+	 * catch (AuthenticationException e) {
+	 *     String challenge = e.getResponseHeader("WWW-Authenticate");
+	 *     // Bearer realm="Intuit", error="invalid_token", error_description="Token expired"
+	 * }
+	 * </pre>
+	 *
+	 * @return the response headers, never null
+	 */
+	public Map<String, String> getResponseHeaders() {
+		if (responseHeaders == null) {
+			return Collections.emptyMap();
+		}
+		return responseHeaders;
+	}
+
+	/**
+	 * Method to get a single response header by name, case-insensitively.
+	 *
+	 * @param name the header name
+	 * @return the header value, or null if absent
+	 */
+	public String getResponseHeader(String name) {
+		if (responseHeaders == null || name == null) {
+			return null;
+		}
+		return responseHeaders.get(name);
+	}
+
+	/**
+	 * Method to set the response headers. Keys are re-indexed case-insensitively.
+	 *
+	 * @param responseHeaders the response headers
+	 */
+	public void setResponseHeaders(Map<String, String> responseHeaders) {
+		if (responseHeaders == null) {
+			this.responseHeaders = null;
+			return;
+		}
+		Map<String, String> headers = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+		headers.putAll(responseHeaders);
+		this.responseHeaders = headers;
+	}
+
 	/**
 	 * Method to get the error codes received from server as String message
 	 * 

--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HTTPBatchClientConnectionInterceptor.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HTTPBatchClientConnectionInterceptor.java
@@ -149,6 +149,7 @@ public class HTTPBatchClientConnectionInterceptor implements Interceptor {
             originalResponseElements.setResponseContent(   receivedResponseElements.getResponseContent()   );
             originalResponseElements.setEncodingHeader(    receivedResponseElements.getEncodingHeader()    );
             originalResponseElements.setContentTypeHeader( receivedResponseElements.getContentTypeHeader() );
+            originalResponseElements.setResponseHeaders(   receivedResponseElements.getResponseHeaders()   );
             originalResponseElements.setStatusLine(        receivedResponseElements.getStatusLine()        );
             originalResponseElements.setStatusCode(        receivedResponseElements.getStatusCode()        );
 
@@ -458,6 +459,7 @@ public class HTTPBatchClientConnectionInterceptor implements Interceptor {
         {
             responseElements.setContentTypeHeader(null);
         }
+        responseElements.setResponseHeaders(httpResponse.getAllHeaders());
         responseElements.setStatusLine(httpResponse.getStatusLine());
         responseElements.setStatusCode(httpResponse.getStatusLine().getStatusCode());
         try {

--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HTTPClientConnectionInterceptor.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HTTPClientConnectionInterceptor.java
@@ -359,6 +359,7 @@ public class HTTPClientConnectionInterceptor implements Interceptor {
 		{
 			responseElements.setContentTypeHeader(null);
 		}
+		responseElements.setResponseHeaders(httpResponse.getAllHeaders());
 		responseElements.setStatusLine(httpResponse.getStatusLine());
 		responseElements.setStatusCode(httpResponse.getStatusLine().getStatusCode());
 		try {

--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HTTPURLConnectionInterceptor.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HTTPURLConnectionInterceptor.java
@@ -185,7 +185,8 @@ public class HTTPURLConnectionInterceptor implements Interceptor {
 		LOG.debug("Response headers:"+httpUrlConnection.getHeaderFields());
 		ResponseElements responseElements = intuitMessage.getResponseElements();
 		responseElements.setEncodingHeader(httpUrlConnection.getContentEncoding());
-		responseElements.setContentTypeHeader(httpUrlConnection.getContentType());		
+		responseElements.setContentTypeHeader(httpUrlConnection.getContentType());
+		responseElements.setResponseHeaderFields(httpUrlConnection.getHeaderFields());
 		try {
 			responseElements.setStatusCode(httpUrlConnection.getResponseCode());
 			

--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HandleResponseInterceptor.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/HandleResponseInterceptor.java
@@ -85,9 +85,28 @@ public class HandleResponseInterceptor implements Interceptor {
 	 */
 	@Override
 	public void execute(IntuitMessage intuitMessage) throws FMSException {
+		try {
+			handleResponse(intuitMessage);
+		} catch (FMSException e) {
+			// Attach the response headers to every exception raised from this interceptor. Some
+			// failures are only distinguishable from a header - for example the WWW-Authenticate
+			// challenge tells an expired token apart from a revoked one when the fault body does
+			// not. Done here rather than at each throw site so no path is missed.
+			e.setResponseHeaders(intuitMessage.getResponseElements().getResponseHeaders());
+			throw e;
+		}
+	}
+
+	/**
+	 * Validates the response and throws the corresponding exception for the fault codes.
+	 *
+	 * @param intuitMessage the intuit message
+	 * @throws FMSException
+	 */
+	private void handleResponse(IntuitMessage intuitMessage) throws FMSException {
 
 		LOG.debug("Enter HandleResponseInterceptor...");
-		
+
 		IntuitResponse intuitResponse = null;
 		ResponseElements responseElements = intuitMessage.getResponseElements();
 		if(responseElements.getResponse() instanceof TaxService)

--- a/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/ResponseElements.java
+++ b/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/interceptors/ResponseElements.java
@@ -16,7 +16,11 @@
 package com.intuit.ipp.interceptors;
 
 import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
+import org.apache.http.Header;
 import org.apache.http.StatusLine;
 
 import com.intuit.ipp.core.Response;
@@ -71,6 +75,13 @@ public class ResponseElements {
      * contains bytes of the received content
      */
     private InputStream responseBytes;
+
+	/**
+	 * variable responseHeaders - all headers received on the response, keyed case-insensitively.
+	 * Where a header is repeated, the last value received is retained, consistent with the use of
+	 * HttpResponse#getLastHeader for the encoding and content type headers.
+	 */
+	private Map<String, String> responseHeaders = newHeaderMap();
 	
 	/**
 	 * Gets decompressed data 
@@ -218,5 +229,81 @@ public class ResponseElements {
 	}
 
     public void setResponseBytes(InputStream responseBytes) {this.responseBytes = responseBytes;}
-	
+
+	/**
+	 * Gets all response headers, keyed case-insensitively. Never null.
+	 *
+	 * @return the response headers
+	 */
+	public Map<String, String> getResponseHeaders() {
+		return responseHeaders;
+	}
+
+	/**
+	 * Sets the response headers. Keys are re-indexed case-insensitively.
+	 *
+	 * @param responseHeaders the response headers
+	 */
+	public void setResponseHeaders(Map<String, String> responseHeaders) {
+		Map<String, String> headers = newHeaderMap();
+		if (responseHeaders != null) {
+			headers.putAll(responseHeaders);
+		}
+		this.responseHeaders = headers;
+	}
+
+	/**
+	 * Sets the response headers from an Apache HttpResponse. Where a header is repeated, the last
+	 * value received is retained.
+	 *
+	 * @param headers the headers as returned by HttpResponse#getAllHeaders
+	 */
+	public void setResponseHeaders(Header[] headers) {
+		Map<String, String> headerMap = newHeaderMap();
+		if (headers != null) {
+			for (Header header : headers) {
+				if (header != null && header.getName() != null) {
+					headerMap.put(header.getName(), header.getValue());
+				}
+			}
+		}
+		this.responseHeaders = headerMap;
+	}
+
+	/**
+	 * Sets the response headers from an HttpURLConnection. Where a header carries multiple values,
+	 * the last one is retained.
+	 *
+	 * <p>Named separately from {@link #setResponseHeaders(Map)} because both would erase to the same
+	 * signature.
+	 *
+	 * @param headerFields the header fields as returned by HttpURLConnection#getHeaderFields
+	 */
+	public void setResponseHeaderFields(Map<String, List<String>> headerFields) {
+		Map<String, String> headerMap = newHeaderMap();
+		if (headerFields != null) {
+			for (Map.Entry<String, List<String>> entry : headerFields.entrySet()) {
+				// HttpURLConnection returns the status line under a null key
+				if (entry.getKey() == null) {
+					continue;
+				}
+				List<String> values = entry.getValue();
+				if (values != null && !values.isEmpty()) {
+					headerMap.put(entry.getKey(), values.get(values.size() - 1));
+				}
+			}
+		}
+		this.responseHeaders = headerMap;
+	}
+
+	/**
+	 * Creates an empty header map with case-insensitive keys. Header names are case-insensitive per
+	 * RFC 7230, and HTTP/2 lowercases them, so callers must not have to guess the casing.
+	 *
+	 * @return an empty case-insensitive map
+	 */
+	private static Map<String, String> newHeaderMap() {
+		return new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+	}
+
 }

--- a/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/interceptors/ResponseHeadersTest.java
+++ b/ipp-v3-java-devkit/src/test/java/com/intuit/ipp/interceptors/ResponseHeadersTest.java
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.intuit.ipp.interceptors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.Header;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicStatusLine;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.intuit.ipp.data.Error;
+import com.intuit.ipp.data.Fault;
+import com.intuit.ipp.data.IntuitResponse;
+import com.intuit.ipp.exception.AuthenticationException;
+import com.intuit.ipp.exception.FMSException;
+import com.intuit.ipp.exception.InvalidTokenException;
+
+/**
+ * Tests that response headers are captured into {@link ResponseElements} and surfaced on the
+ * exceptions thrown by {@link HandleResponseInterceptor}.
+ *
+ * <p>Some failures are only distinguishable from a header. QuickBooks Online returns error code 3200
+ * for both an expired and a revoked token, and the disambiguating fault detail is not always
+ * populated, so the {@code WWW-Authenticate} challenge is what tells the two apart.
+ *
+ * <p>Self-contained: no credentials, no network.
+ */
+public class ResponseHeadersTest {
+
+	private static final String WWW_AUTHENTICATE = "WWW-Authenticate";
+
+	private static final String EXPIRED_CHALLENGE =
+			"Bearer realm=\"Intuit\", error=\"invalid_token\", error_description=\"Token expired\"";
+
+	private static final String REVOKED_CHALLENGE =
+			"Bearer realm=\"Intuit\", error=\"invalid_token\", error_description=\"Token revoked\"";
+
+	// ---------- ResponseElements normalisation ----------
+
+	@Test
+	public void testApacheHeadersAreLookedUpCaseInsensitively() {
+		ResponseElements responseElements = new ResponseElements();
+		responseElements.setResponseHeaders(new Header[] {
+				new BasicHeader("www-authenticate", EXPIRED_CHALLENGE),
+				new BasicHeader("Content-Type", "application/json")
+		});
+
+		Map<String, String> headers = responseElements.getResponseHeaders();
+		// HTTP/2 lowercases header names, HTTP/1.1 usually title-cases them; both must resolve
+		Assert.assertEquals(headers.get("WWW-Authenticate"), EXPIRED_CHALLENGE);
+		Assert.assertEquals(headers.get("www-authenticate"), EXPIRED_CHALLENGE);
+		Assert.assertEquals(headers.get("content-type"), "application/json");
+	}
+
+	@Test
+	public void testRepeatedApacheHeaderKeepsLastValue() {
+		ResponseElements responseElements = new ResponseElements();
+		responseElements.setResponseHeaders(new Header[] {
+				new BasicHeader("Strict-Transport-Security", "max-age=31536000"),
+				new BasicHeader("Strict-Transport-Security", "max-age=15552000")
+		});
+
+		Assert.assertEquals(responseElements.getResponseHeaders().get("Strict-Transport-Security"),
+				"max-age=15552000");
+	}
+
+	@Test
+	public void testHeaderFieldsFromUrlConnection() {
+		Map<String, List<String>> headerFields = new HashMap<String, List<String>>();
+		headerFields.put("WWW-Authenticate", Arrays.asList(REVOKED_CHALLENGE));
+		headerFields.put("Set-Cookie", Arrays.asList("a=1", "b=2"));
+		// HttpURLConnection returns the status line keyed under null
+		headerFields.put(null, Arrays.asList("HTTP/1.1 401 Unauthorized"));
+
+		ResponseElements responseElements = new ResponseElements();
+		responseElements.setResponseHeaderFields(headerFields);
+
+		Map<String, String> headers = responseElements.getResponseHeaders();
+		Assert.assertEquals(headers.get("www-authenticate"), REVOKED_CHALLENGE);
+		Assert.assertEquals(headers.get("Set-Cookie"), "b=2");
+		// the null-keyed status line entry is dropped, leaving only the two real headers
+		Assert.assertEquals(headers.size(), 2);
+	}
+
+	@Test
+	public void testHeadersDefaultToEmptyNotNull() {
+		Assert.assertNotNull(new ResponseElements().getResponseHeaders());
+		Assert.assertTrue(new ResponseElements().getResponseHeaders().isEmpty());
+	}
+
+	@Test
+	public void testNullHeadersAreTolerated() {
+		ResponseElements responseElements = new ResponseElements();
+		responseElements.setResponseHeaders((Header[]) null);
+		Assert.assertTrue(responseElements.getResponseHeaders().isEmpty());
+
+		responseElements.setResponseHeaderFields(null);
+		Assert.assertTrue(responseElements.getResponseHeaders().isEmpty());
+	}
+
+	// ---------- exception enrichment ----------
+
+	@Test
+	public void testFaultExceptionCarriesResponseHeaders() {
+		IntuitMessage intuitMessage = faultMessage("Authentication", "3200");
+		intuitMessage.getResponseElements().setResponseHeaders(new Header[] {
+				new BasicHeader("www-authenticate", EXPIRED_CHALLENGE)
+		});
+
+		try {
+			new HandleResponseInterceptor().execute(intuitMessage);
+			Assert.fail("Expected AuthenticationException");
+		} catch (FMSException e) {
+			Assert.assertTrue(e instanceof AuthenticationException);
+			Assert.assertEquals(e.getResponseHeader(WWW_AUTHENTICATE), EXPIRED_CHALLENGE);
+			// the header is what distinguishes this from a revoked token - code 3200 does not
+			Assert.assertEquals(e.getErrorList().get(0).getCode(), "3200");
+		}
+	}
+
+	@Test
+	public void testStatusCodeFallbackExceptionCarriesResponseHeaders() {
+		// No parseable IntuitResponse, so HandleResponseInterceptor falls back to the status code
+		IntuitMessage intuitMessage = new IntuitMessage();
+		ResponseElements responseElements = intuitMessage.getResponseElements();
+		responseElements.setStatusLine(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 401, "Unauthorized"));
+		responseElements.setStatusCode(401);
+		responseElements.setResponseHeaders(new Header[] {
+				new BasicHeader("WWW-Authenticate", REVOKED_CHALLENGE)
+		});
+
+		try {
+			new HandleResponseInterceptor().execute(intuitMessage);
+			Assert.fail("Expected InvalidTokenException");
+		} catch (FMSException e) {
+			Assert.assertTrue(e instanceof InvalidTokenException);
+			Assert.assertEquals(e.getResponseHeader("www-authenticate"), REVOKED_CHALLENGE);
+		}
+	}
+
+	@Test
+	public void testExceptionWithoutHeadersReturnsEmptyMap() {
+		FMSException e = new FMSException("no headers captured");
+		Assert.assertNotNull(e.getResponseHeaders());
+		Assert.assertTrue(e.getResponseHeaders().isEmpty());
+		Assert.assertNull(e.getResponseHeader(WWW_AUTHENTICATE));
+		Assert.assertNull(e.getResponseHeader(null));
+	}
+
+	@Test
+	public void testLookupsAreNullSafeAndMissesReturnNull() {
+		IntuitMessage intuitMessage = faultMessage("Authentication", "3200");
+		intuitMessage.getResponseElements().setResponseHeaders(new Header[] {
+				new BasicHeader("WWW-Authenticate", EXPIRED_CHALLENGE)
+		});
+
+		try {
+			new HandleResponseInterceptor().execute(intuitMessage);
+			Assert.fail("Expected AuthenticationException");
+		} catch (FMSException e) {
+			// the map is ordered by a case-insensitive comparator, so a raw get(null) would throw;
+			// the accessor must absorb that for callers
+			Assert.assertNull(e.getResponseHeader(null));
+			Assert.assertNull(e.getResponseHeader("X-Not-Present"));
+		}
+	}
+
+	// ---------- helpers ----------
+
+	private IntuitMessage faultMessage(String faultType, String errorCode) {
+		Error error = new Error();
+		error.setCode(errorCode);
+		error.setMessage("message=AuthenticationFailed; errorCode=00" + errorCode + "; statusCode=401");
+
+		List<Error> errors = new ArrayList<Error>();
+		errors.add(error);
+
+		Fault fault = new Fault();
+		fault.setType(faultType);
+		fault.setError(errors);
+
+		IntuitResponse intuitResponse = new IntuitResponse();
+		intuitResponse.setFault(fault);
+
+		IntuitMessage intuitMessage = new IntuitMessage();
+		intuitMessage.getResponseElements().setResponse(intuitResponse);
+		return intuitMessage;
+	}
+}


### PR DESCRIPTION
## Problem

Some API failures are only distinguishable from a response header, and the SDK discards all of them.

QuickBooks Online returns `errorCode=003200` with a byte-identical `message` for **both** an expired access token and a revoked one. The only body field that distinguishes them is `fault.error[].detail`, and that field is not always populated — in Production it comes back `null` for a revoked token while Sandbox returns `"Token revoked"`. Support case: https://help.developer.intuit.com/s/case/500TR00001m9I8UYAU/v3-api-faulterrordetail-returned-as-null-in-production-but-populated-in-sandbox-for-401-errorcode003200

The `WWW-Authenticate` response header does carry the distinction reliably in both environments:

```
www-authenticate: Bearer realm="Intuit", error="invalid_token", error_description="Token expired"
www-authenticate: Bearer realm="Intuit", error="invalid_token", error_description="Token revoked"
```

This matters because the correct client behaviour is opposite in the two cases: an expired token should be refreshed and retried, whereas a revoked grant is unrecoverable and requires the user to re-authorize. A client that cannot tell them apart will either retry forever or discard a connection whose refresh token is still perfectly good.

Today an SDK caller cannot reach that header:

- `HTTPClientConnectionInterceptor.setResponseElements()` copies only `Content-Encoding`, `Content-Type` and the status line off the `HttpResponse`.
- `ResponseElements` has no generic header map, so everything else is gone before any exception is constructed.
- `FMSException` therefore has nothing to expose.

The only workaround is to bypass `DataService` and re-issue the request with a raw HTTP client purely to read one header — for a condition the SDK's own exception hierarchy already models as `AuthenticationException`.

Worth noting `HTTPURLConnectionInterceptor` already logs the full header map (`LOG.debug("Response headers:" + httpUrlConnection.getHeaderFields())`) and then drops it on the next line.

## Change

```java
try {
    service.findById(customer);
} catch (AuthenticationException e) {
    String challenge = e.getResponseHeader("WWW-Authenticate");
    // Bearer realm="Intuit", error="invalid_token", error_description="Token expired"
}
```

- **`ResponseElements`** holds all response headers in a case-insensitive map. Case-insensitivity is required rather than cosmetic: header names are case-insensitive per RFC 7230 and HTTP/2 lowercases them, so callers must not have to guess. Where a header repeats, the last value is retained — consistent with the existing use of `HttpResponse#getLastHeader` for the two headers already captured.
- **The three connection interceptors** populate it: `HTTPClientConnectionInterceptor`, `HTTPBatchClientConnectionInterceptor`, and `HTTPURLConnectionInterceptor` (the last via `getHeaderFields()`, whose multi-value entries and null-keyed status line are normalised).
- **`HandleResponseInterceptor`** attaches the headers to every `FMSException` it raises. Done once around the existing logic rather than at each of the 13 throw sites, so no path is missed and future ones are covered automatically. Batch requests are included, since `IntuitBatchInterceptorProvider` inherits the response chain and only swaps the request interceptor.
- **`FMSException`** exposes `getResponseHeaders()` and `getResponseHeader(name)`. The map accessor returns an empty map rather than `null`, and both tolerate a `null` name. All subclasses inherit this.

## Compatibility

Additive only — new fields and methods, no signature or behaviour changes, no new dependencies, Java 8 compatible. Existing callers are unaffected.

**Known limitation:** repeated headers such as `Set-Cookie` keep only the last value. `Map<String, List<String>>` would preserve them, but single-value lookups are the use case here and a flat map matches the SDK's existing style. Happy to change this if you'd prefer.

## Tests

Adds `ResponseHeadersTest` (9 tests, TestNG) — no credentials, no network:

- header normalisation from both the Apache `Header[]` and `HttpURLConnection` `getHeaderFields()` sources
- case-insensitive lookup (`WWW-Authenticate` and `www-authenticate` both resolve)
- repeated header keeps the last value; null-keyed status line entry is dropped
- enrichment on the fault path (`AuthenticationException`) and the status-code fallback path (`InvalidTokenException`)
- null safety: empty map rather than null, `getResponseHeader(null)` returns null

It lands in `com.intuit.ipp.interceptors`, which `testng-devkit.xml` already includes by package, so no suite changes were needed.

Verified with `mvn -pl ipp-v3-java-devkit test-compile surefire:test -Dtest=ResponseHeadersTest` (9/9 passing) plus the adjacent self-contained interceptor and exception suites (35/35, no regressions).
